### PR TITLE
Add PKO-specific HLF CRD

### DIFF
--- a/hack/hypershift/package/hypershift-logging-operator.Containerfile
+++ b/hack/hypershift/package/hypershift-logging-operator.Containerfile
@@ -1,3 +1,2 @@
 FROM scratch
-ADD deploy/crds/logging.managed.openshift.io_hypershiftlogforwarders.yaml /package/
 ADD ./hack/hypershift/package/*.yaml* /package/

--- a/hack/hypershift/package/logging.managed.openshift.io_hypershiftlogforwarders.yaml
+++ b/hack/hypershift/package/logging.managed.openshift.io_hypershiftlogforwarders.yaml
@@ -3,7 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
+    controller-gen.kubebuilder.io/version: v0.10.0
+    # see deploy/package/manifest.yaml
+    package-operator.run/phase: hosted-cluster
   creationTimestamp: null
   name: hypershiftlogforwarders.logging.managed.openshift.io
 spec:
@@ -12,8 +14,6 @@ spec:
     kind: HyperShiftLogForwarder
     listKind: HyperShiftLogForwarderList
     plural: hypershiftlogforwarders
-    shortNames:
-    - hlf
     singular: hypershiftlogforwarder
   scope: Namespaced
   versions:

--- a/hack/hypershift/package/manifest.yaml
+++ b/hack/hypershift/package/manifest.yaml
@@ -7,7 +7,7 @@ spec:
     - Namespaced
   phases:
     # see deploy/crds/logging.managed.openshift.io_hypershiftlogforwarders.yaml
-    - name: hlf
+    - name: hosted-cluster
       class: hosted-cluster
 
   # see https://package-operator.run/docs/concepts/probes/#customresourcedefinition


### PR DESCRIPTION
Based on internal discussion, we want to put all of our PKO specific manifests in the same place - even if it means duplicating some things. This PR does that by duplicating the HLF CRD into the PKO manifest location. Follows convention of addon operator: https://github.com/openshift/addon-operator/blob/main/config/deploy/addons.managed.openshift.io_addoninstances.yaml