### PR TITLE
Add cluster scope to package manifest

### DIFF
--- a/hack/hypershift/package/manifest.yaml
+++ b/hack/hypershift/package/manifest.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   scopes:
     - Namespaced
+    - Cluster
   phases:
     # see deploy/crds/logging.managed.openshift.io_hypershiftlogforwarders.yaml
     - name: hosted-cluster


### PR DESCRIPTION
Fixes issue with installing HLF CRD where cluster-scoped resources need to be called out in package. 
More info here: https://redhat-internal.slack.com/archives/C0326L38PEH/p1695770781838469?thread_ts=1695704113.202859&cid=C0326L38PEH
https://package-operator.run/docs/concepts/scopes/