### PR TITLE
OSD-18529 - Update SSS label for operator deployment

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -36,7 +36,7 @@ objects:
     spec:
       clusterDeploymentSelector:
         matchLabels:
-          api.openshift.com/managed: "true"
+          ext-hypershift.openshift.io/cluster-type: management-cluster
       resourceApplyMode: Sync
       resources:
         - apiVersion: v1


### PR DESCRIPTION
SSS label update to deploy the operator only on `management-cluster`.