### PR TITLE
Fix hosted cluster being active after submanger shutdown

### DIFF
--- a/controllers/hostedcluster/hostedcluster_controller.go
+++ b/controllers/hostedcluster/hostedcluster_controller.go
@@ -168,6 +168,8 @@ func (r *HostedClusterReconciler) Reconcile(
 			cancelFunc()
 			r.log.V(1).Info("stop the manager", "controller name", hostedClusters[req.NamespacedName.Name])
 
+			//delete hosted cluster from the map since it may create / active again
+			delete(hostedClusters, req.NamespacedName.Name)
 		}
 	}
 


### PR DESCRIPTION
## Why 
When the hosted cluster is unresponsive from `hostedcluster` resources, then the corresponding sub-manger will shut down. If the same cluster is active again, then it may not create a new sub-manger since it's in the map .  This PR will delete hostedcluster from the map once shut-down the submanger. 