### PR TITLE
OSD-19091 : update ubi8 tag to 8.8-1072.1696517598 version

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -23,7 +23,7 @@ RUN make go-build
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM  registry.access.redhat.com/ubi8/ubi-minimal:8.8-1072
+FROM  registry.access.redhat.com/ubi8/ubi-minimal:8.8-1072.1696517598
 ENV USER_UID=1001 \
     USER_NAME=hypershift-logging-operator
 


### PR DESCRIPTION
## Why 
Opertaor image throws security [vulnerabilities issues](https://quay.io/repository/app-sre/hypershift-logging-operator?tab=tags)