### PR TITLE
[OSD-19015] watch the hosted cluster creation in template controller

### DIFF
--- a/controllers/clusterlogforwardertemplate/event_handler.go
+++ b/controllers/clusterlogforwardertemplate/event_handler.go
@@ -1,0 +1,74 @@
+package clusterlogforwardertemplate
+
+import (
+	"context"
+	"fmt"
+
+	hyperv1beta1 "github.com/openshift/hypershift/api/v1beta1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var _ handler.EventHandler = &enqueueRequestForHostedControlPlane{}
+
+type enqueueRequestForHostedControlPlane struct {
+	Client client.Client
+}
+
+func (e *enqueueRequestForHostedControlPlane) mapAndEnqueue(q workqueue.RateLimitingInterface, obj client.Object, reqs map[reconcile.Request]struct{}) {
+	for _, req := range e.mapToRequests(obj) {
+		_, ok := reqs[req]
+		if !ok {
+			q.Add(req)
+			// Used for de-duping requests
+			reqs[req] = struct{}{}
+		}
+	}
+}
+
+func (e *enqueueRequestForHostedControlPlane) mapToRequests(obj client.Object) []reconcile.Request {
+	reqs := []reconcile.Request{}
+	hcpList := &hyperv1beta1.HostedControlPlaneList{}
+
+	err := e.Client.List(context.TODO(), hcpList, &client.ListOptions{Namespace: obj.GetNamespace()})
+	if err != nil {
+		return reqs
+	}
+
+	for _, h := range hcpList.Items {
+		reqs = append(reqs, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      "instance",
+				Namespace: h.Namespace,
+			},
+		})
+	}
+
+	fmt.Println(reqs)
+	return reqs
+}
+
+func (e *enqueueRequestForHostedControlPlane) Create(evt event.CreateEvent, q workqueue.RateLimitingInterface) {
+	reqs := map[reconcile.Request]struct{}{}
+	e.mapAndEnqueue(q, evt.Object, reqs)
+}
+
+func (e *enqueueRequestForHostedControlPlane) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
+	reqs := map[reconcile.Request]struct{}{}
+	e.mapAndEnqueue(q, evt.ObjectOld, reqs)
+	e.mapAndEnqueue(q, evt.ObjectNew, reqs)
+}
+
+func (e *enqueueRequestForHostedControlPlane) Delete(evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
+	reqs := map[reconcile.Request]struct{}{}
+	e.mapAndEnqueue(q, evt.Object, reqs)
+}
+
+func (e *enqueueRequestForHostedControlPlane) Generic(evt event.GenericEvent, q workqueue.RateLimitingInterface) {
+	reqs := map[reconcile.Request]struct{}{}
+	e.mapAndEnqueue(q, evt.Object, reqs)
+}

--- a/controllers/clusterlogforwardertemplate/event_handler.go
+++ b/controllers/clusterlogforwardertemplate/event_handler.go
@@ -2,7 +2,6 @@ package clusterlogforwardertemplate
 
 import (
 	"context"
-	"fmt"
 
 	hyperv1beta1 "github.com/openshift/hypershift/api/v1beta1"
 	"k8s.io/apimachinery/pkg/types"
@@ -47,8 +46,6 @@ func (e *enqueueRequestForHostedControlPlane) mapToRequests(obj client.Object) [
 			},
 		})
 	}
-
-	fmt.Println(reqs)
 	return reqs
 }
 

--- a/main.go
+++ b/main.go
@@ -30,13 +30,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	"github.com/openshift/hypershift-logging-operator/api/v1alpha1"
-
-	"github.com/openshift/hypershift-logging-operator/controllers/clusterlogforwardertemplate"
-	hostedclustercontroller "github.com/openshift/hypershift-logging-operator/controllers/hostedcluster"
-
 	loggingv1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	hyperv1beta1 "github.com/openshift/hypershift/api/v1beta1"
+
+	"github.com/openshift/hypershift-logging-operator/api/v1alpha1"
+	"github.com/openshift/hypershift-logging-operator/controllers/clusterlogforwardertemplate"
+	hostedclustercontroller "github.com/openshift/hypershift-logging-operator/controllers/hostedcluster"
 )
 
 var (

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -6,4 +6,5 @@ const (
 	SingletonName                 = "instance"
 	ManagedLoggingFinalizer       = "logging.managed.openshift.io"
 	HLFWatchedNamespace           = "openshift-logging"
+	OperatorNamespace             = "openshift-hypershift-logging-operator"
 )


### PR DESCRIPTION
Update the CLFT controller to watch the hosted cluster creation with the hostedcontrolplane resource.

Fix the existing logic to put the declare of the clf into the for loop, so it can get a new blank one for each iteration.

Close https://issues.redhat.com/browse/OSD-19015
