### PR TITLE
Change skopeo-push to podman-push

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,17 +47,14 @@ build-package:
 		$(CONTAINER_ENGINE) build -t $(PKO_IMG):$(PKO_IMAGETAG) -f $(join $(CURDIR),/hack/hypershift/package/hypershift-logging-operator.Containerfile) . && \
 		$(CONTAINER_ENGINE) tag $(PKO_IMG):$(PKO_IMAGETAG) $(PKO_IMG):latest
 
-.PHONY: skopeo-push
-skopeo-push-package:
+.PHONY: podman-push
+podman-push-package:
 	@if [[ -z $$QUAY_USER || -z $$QUAY_TOKEN ]]; then \
 		echo "You must set QUAY_USER and QUAY_TOKEN environment variables" ;\
 		echo "ex: make QUAY_USER=value QUAY_TOKEN=value $@" ;\
 		exit 1 ;\
 	fi
 	# QUAY_USER and QUAY_TOKEN are supplied as env vars
-	skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
-		"docker-daemon:${PKO_IMG}:${PKO_IMAGETAG}" \
-		"docker://${PKO_IMG}:latest"
-	skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
-		"docker-daemon:${PKO_IMG}:${PKO_IMAGETAG}" \
-		"docker://${PKO_IMG}:${PKO_IMAGETAG}"
+	podman login -u="${QUAY_USER}" -p="${QUAY_TOKEN}" quay.io
+	podman push $(PKO_IMG):$(PKO_IMAGETAG)
+	podman push $(PKO_IMG):latest

--- a/build/build_package.sh
+++ b/build/build_package.sh
@@ -90,4 +90,4 @@ if image_exists_in_repo "$IMAGE_URI"; then
 fi
 
 # build the image and push the image
-make -C $(dirname $0)/../ build-package skopeo-push-package
+make -C $(dirname $0)/../ build-package podman-push-package


### PR DESCRIPTION
### What type of PR is this?

bug

### What this PR does / Why we need it?

The CI build pipeline failed due to the build machine has migrated to podman recently.
https://ci.int.devshift.net/view/osd-operators/job/openshift-hypershift-logging-operator-gh-build-main/49/console
```
09:20:04 skopeo copy --dest-creds "****:****" \
09:20:04 	"docker-daemon:quay.io/app-sre/hypershift-logging-operator-package:54505f4" \
09:20:04 	"docker://quay.io/app-sre/hypershift-logging-operator-package:latest"
09:20:05 time="2024-07-19T01:20:05Z" level=fatal msg="initializing source docker-daemon:quay.io/app-sre/hypershift-logging-operator-package:54505f4: loading image from docker engine: permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Get \"http://%2Fvar%2Frun%2Fdocker.sock/v1.24/images/get?names=quay.io%2Fapp-sre%2Fhypershift-logging-operator-package%3A54505f4\": dial unix /var/run/docker.sock: connect: permission denied"
09:20:05 make[1]: *** [Makefile:54: skopeo-push-package] Error 1
```

The fix is to use podman instead.
Example fix from boilerplate https://github.com/openshift/boilerplate/commit/72c3b82e6b8daceb25888a60aa55a5117b969e71 

In this repo, the `skopeo-push-package` in Makefile is for making the PKO package, which is outside the boilerplate, so updating boilerplate doesn't fix the issue and we need fix it manually.

The CI pipeline calls `build/build_deploy.sh`->`make build-package-push`->`build/build_package.sh`->`make build-package skopeo-push-package`, so changing `skopeo-push-package` to use podman should fix the issue.

### Which Jira/Github issue(s) does this PR fix?

[OSD-24536](https://issues.redhat.com//browse/OSD-24536) is blocked by the CI build failure.

### Special notes for your reviewer

### Pre-checks (if applicable)

- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR